### PR TITLE
update prompt to exclude version bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: asdf-vm/actions/install@v3
+      - run: pnpm install
+      - run: pnpm build
       - uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A GitHub Action that automatically identifies [User-Visible Improvements](https:
 
 - 🔍 Automatically detects user-visible improvements in PR changes and pushes
 - 🤖 Uses OpenAI's API for intelligent analysis
+- 🧠 Understands product context from README to provide more relevant results
 - 💬 Maintains an up-to-date comment in PRs listing all identified UVIs
 - 📊 Exposes UVI count and details as outputs for use in other workflow steps
 - 🔄 Updates automatically when changes are pushed
@@ -96,6 +97,24 @@ steps:
       echo "Found ${{ steps.uvi.outputs.uvi-count }} improvements"
       echo "Improvements: ${{ steps.uvi.outputs.uvi-list }}"
 ```
+
+## How It Works
+
+1. **Product Understanding**: The action first analyzes your project's README to understand:
+   - What your product does
+   - Who your users are
+   - How they use your product
+   This context helps ensure that identified improvements are relevant to your specific users.
+
+2. **Change Analysis**: Changes are analyzed in chunks to stay within OpenAI's context limits, with each chunk evaluated for:
+   - New features and functionality
+   - Bug fixes and error handling improvements
+   - UI and UX enhancements
+   - Performance optimizations
+   - Documentation updates
+
+3. **Output**: 
+   - Findings are added as PR comments and action outputs
 
 ## Action Output
 

--- a/knowledge.md
+++ b/knowledge.md
@@ -21,12 +21,14 @@
 - Results from multiple chunks are deduplicated by description before returning
 - Package lock files (package-lock.json, yarn.lock, etc.) are automatically excluded from analysis
 - Version number changes are not considered UVIs, even though they often accompany them
+- Project README is analyzed first to understand product context and user needs
 
 ## Implementation Details
 - Diffs are split by file boundaries to maintain context
 - Each chunk is analyzed separately and results are merged
 - Duplicate improvements (same description) are removed to prevent redundancy
 - Lock files are filtered out before chunking to reduce noise and token usage
+- Product context from README helps tailor UVI detection to the specific project
 
 ## Build Process
 The action is bundled into a single file using @vercel/ncc, which includes all dependencies. This eliminates the need to install dependencies when running the action. The build command uses the `-m` flag to minify the output and reduce bundle size.

--- a/knowledge.md
+++ b/knowledge.md
@@ -20,6 +20,7 @@
 - Large diffs are automatically chunked into ~4000 token pieces to stay within model context limits
 - Results from multiple chunks are deduplicated by description before returning
 - Package lock files (package-lock.json, yarn.lock, etc.) are automatically excluded from analysis
+- Version number changes are not considered UVIs, even though they often accompany them
 
 ## Implementation Details
 - Diffs are split by file boundaries to maintain context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uvi-finder",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "GitHub Action to find user-visible improvements in pull requests",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uvi-finder",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "GitHub Action to find user-visible improvements in pull requests",
   "main": "dist/index.js",
   "type": "module",

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,3 +40,11 @@ export interface UVI {
   category?: string;
   impact?: string;
 }
+
+export interface GetProductContextOptions {
+  octokit: ReturnType<typeof getOctokit>;
+  openai: OpenAI;
+  model: string;
+  owner: string;
+  repo: string;
+}

--- a/src/uvi-finder.ts
+++ b/src/uvi-finder.ts
@@ -1,9 +1,66 @@
-import type { FindUVIsOptions } from "./types.js";
+import type { FindUVIsOptions, GetProductContextOptions } from "./types.js";
 import { OpenAIResponseSchema } from "./schemas.js";
 import * as core from "@actions/core";
 
+const PRODUCT_CONTEXT_PROMPT = `You are an expert at understanding software products and their users.
+Your task is to analyze the provided README file and summarize:
+1. What the product does
+2. Who the users are
+3. What they use it for
+
+Keep your response brief and focused on the user perspective. Avoid technical implementation details.`;
+
+async function getProductContext(
+  options: GetProductContextOptions
+): Promise<string> {
+  const { octokit, openai, model, owner, repo } = options;
+
+  try {
+    // Get the README content
+    const { data } = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: "README.md",
+    });
+
+    // Extract content from the response
+    const content = Buffer.from(
+      "content" in data ? data.content : "",
+      "base64"
+    ).toString("utf8");
+
+    // Get OpenAI's understanding of the product
+    const completion = await openai.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: PRODUCT_CONTEXT_PROMPT },
+        { role: "user", content: content },
+      ],
+      temperature: 0.2,
+    });
+
+    const context = completion.choices[0]?.message?.content || "";
+
+    core.info(`Product context: ${context}`);
+
+    return context;
+  } catch (error: unknown) {
+    core.warning(
+      "Failed to get product context from README. Proceeding without it."
+    );
+    if (error instanceof Error) {
+      core.warning(error.message);
+    }
+    return "";
+  }
+}
+
 const SYSTEM_PROMPT = `You are an expert at identifying user-visible improvements (UVIs) in code changes.
 Your task is to analyze the provided code diff and identify ONLY changes that would be directly visible or meaningful to end users.
+
+First, look at the files being changed to understand the product's purpose and its users. This context will help you better identify what constitutes a meaningful improvement for this specific product.
+
+Then, analyze the changes to identify UVIs, considering:
 
 Include:
 - New features that users can see or interact with
@@ -102,6 +159,15 @@ function chunkDiff(diff: string): {
 export async function findUVIs(options: FindUVIsOptions) {
   const { octokit, openai, model, owner, repo } = options;
 
+  // Get product context first
+  const productContext = await getProductContext({
+    octokit,
+    openai,
+    model,
+    owner,
+    repo,
+  });
+
   // Get the diff either from PR or commit comparison
   let diffText;
   if ("pullNumber" in options) {
@@ -147,6 +213,14 @@ export async function findUVIs(options: FindUVIsOptions) {
       model,
       messages: [
         { role: "system", content: SYSTEM_PROMPT },
+        ...(productContext
+          ? [
+              {
+                role: "user" as const,
+                content: `Product Context:\n${productContext}`,
+              },
+            ]
+          : []),
         {
           role: "user",
           content: `Please analyze this diff for user-visible improvements:\n\n${chunk}`,

--- a/src/uvi-finder.ts
+++ b/src/uvi-finder.ts
@@ -21,6 +21,7 @@ Exclude:
 - Development tooling updates
 - Package updates that don't affect user experience
 - Internal documentation changes
+- Version number changes or version bumps (these are not UVIs themselves)
 
 Your response should be valid JSON with this exact structure:
 {
@@ -31,7 +32,9 @@ Your response should be valid JSON with this exact structure:
       "impact": "Optional description of the impact"
     }
   ]
-}`;
+}
+
+Important: Do not include version number changes as improvements. While version bumps often accompany UVIs, they are not UVIs themselves.`;
 
 const MAX_CHUNK_SIZE = 4000; // Conservative limit to leave room for prompts
 


### PR DESCRIPTION
This pull request updates the `uvi-finder` project to clarify that version number changes are not considered user-visible improvements (UVIs) and ensures this rule is consistently applied across the codebase and documentation.

### Clarifications on version number changes:

* [`knowledge.md`](diffhunk://#diff-7451ebf321da90126be0c3eaa792676854388744817cee5ef353dec33a4a1219R23): Added a note specifying that version number changes are not considered UVIs, even though they often accompany them.
* [`src/uvi-finder.ts`](diffhunk://#diff-7ea8851ce9b84d79d506f8584f7f5e84562278f3d110b88e5c4efceaf4134f35R24): Updated the exclusion list to explicitly state that version number changes or bumps are not UVIs.
* [`src/uvi-finder.ts`](diffhunk://#diff-7ea8851ce9b84d79d506f8584f7f5e84562278f3d110b88e5c4efceaf4134f35L34-R37): Added a note in the JSON response guidelines to emphasize that version number changes should not be treated as improvements.

### Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version of the `uvi-finder` package from `1.5.1` to `1.5.2`.